### PR TITLE
Fix failing tests

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -366,14 +366,6 @@ scenarios:
     runCode(mockData);
 
     assertApi('setResponseHeader').wasCalledWith('Access-Control-Allow-Origin', 'https://www.otherdomain.com');
-- name: Return successful response with multiple origins
-  code: |-
-    mockData.approvedOrigin = 'https://www.firstdomain.com,https://www.seconddomain.com';
-
-    runCode(mockData);
-
-    assertApi('setResponseHeader').wasCalledWith('Access-Control-Allow-Origin', 'https://www.firstdomain.com');
-    assertApi('setResponseHeader').wasCalledWith('Access-Control-Allow-Origin', 'https://www.seconddomain.com');
 setup: |-
   const mockData = {
     approvedOrigin: 'https://www.domain.com',

--- a/template.tpl
+++ b/template.tpl
@@ -360,7 +360,7 @@ scenarios:
       if (h === 'origin') return 'https://www.otherdomain.com';
     });
 
-    mockData.approvedOrigins = '*';
+    mockData.approvedOrigin = '*';
 
     // Call runCode to run the template's code.
     runCode(mockData);
@@ -368,7 +368,7 @@ scenarios:
     assertApi('setResponseHeader').wasCalledWith('Access-Control-Allow-Origin', 'https://www.otherdomain.com');
 - name: Return successful response with multiple origins
   code: |-
-    mockData.approvedOrigins = 'https://www.firstdomain.com,https://www.seconddomain.com';
+    mockData.approvedOrigin = 'https://www.firstdomain.com,https://www.seconddomain.com';
 
     runCode(mockData);
 
@@ -376,7 +376,7 @@ scenarios:
     assertApi('setResponseHeader').wasCalledWith('Access-Control-Allow-Origin', 'https://www.seconddomain.com');
 setup: |-
   const mockData = {
-    approvedOrigins: 'https://www.domain.com',
+    approvedOrigin: 'https://www.domain.com',
     approvedMethods: 'GET,POST',
     approvedHeaders: 'content-type'
   };

--- a/template.tpl
+++ b/template.tpl
@@ -360,7 +360,7 @@ scenarios:
       if (h === 'origin') return 'https://www.otherdomain.com';
     });
 
-    mockData.approvedOrigin = '*';
+    mockData.approvedOrigin = 'auto';
 
     // Call runCode to run the template's code.
     runCode(mockData);


### PR DESCRIPTION
As discussed in the [Team Simmer Zulip](https://chat.teamsimmer.com/#narrow/stream/3-server-side-tagging/topic/CORS/near/5285) I've made some small updates to this template to:

- [x] Fix references in mock data to `allowedOrigins` to be `allowedOrigin` (singular) as per the field name.
- [x] Set the `mockData` to use the word `auto` for wildcard origins as opposed to the `*` specified in the test.
- [x] Removed the test for setting multiple origins, as this isn't allowed by the standard and is prevented from being supplied in the field by the validation RegEx anyway (`^(http(s)?://[^/]+|auto)$`—can't enter additional forward slashes after the initial protocol).

Remaining three tests now pass:
![image](https://user-images.githubusercontent.com/1005395/132424916-4bfb78bf-e9bc-45ff-8ca8-a64b6097edff.png)
